### PR TITLE
Add missing file used in tests

### DIFF
--- a/xml-html-conduit-lens.cabal
+++ b/xml-html-conduit-lens.cabal
@@ -14,6 +14,8 @@ cabal-version:       >= 1.10
 extra-source-files:
   README.md
   CHANGELOG.md
+  example/queries.hs
+  example/books.xml
 
 source-repository head
   type: git


### PR DESCRIPTION
Currently it's impossible to test this package during installation from a hackage

```
- 107running tests

    108Running 2 test suites...
    109Test suite doctest: RUNNING...
    110
    111<no location info>: can't find file: example/queries.hs
    112Test suite doctest: FAIL
```
