### PR TITLE
Add examples/namespaces.* to .cabal file

### DIFF
--- a/xml-html-conduit-lens.cabal
+++ b/xml-html-conduit-lens.cabal
@@ -16,6 +16,8 @@ extra-source-files:
   CHANGELOG.md
   example/books.hs
   example/books.xml
+  example/namespaces.hs
+  example/namespaces.xml
   example/ridna-mova.hs
   example/yandex-weather.hs
 


### PR DESCRIPTION
Cabal checks currently fail when fetching the source from Hackage due to not being able to find examples/namespaces.hs. This *should* fix that, as far as I understand.